### PR TITLE
MBUILD-60 MBUILD-80 Minor CP Fixes

### DIFF
--- a/AdventureGame/ContextParser.cpp
+++ b/AdventureGame/ContextParser.cpp
@@ -3,6 +3,7 @@
 #include <ctype.h>
 #include <vector>
 #include <string>
+#include <regex>
 
 using namespace std;
 
@@ -55,17 +56,20 @@ bool ContextParser::interpretCommand(string unfilteredCmd)
         return false;
     }
 
+    // RegEx query to match the whole world.
+    regex exp ("\\b("+formattedCmd[0]+")\\b");
+
     // Figure out what command this is for.
 
-    if (locationManager::getValidCommands().find(formattedCmd[0] + " ") != std::string::npos)
+    if (regex_search(locationManager::getValidCommands(), exp))
     {
         return locationManager::processCommand(formattedCmd);
     }
-    else if (inventoryMGR->inventoryValidCommands.find(formattedCmd[0] + " ") != std::string::npos)
+    else if (regex_search(inventoryMGR->inventoryValidCommands,exp))
     {
         return inventoryMGR->processCommand(formattedCmd);
     }
-    else if (playerActionsMGR->playerActionsValidCommands.find(formattedCmd[0]+" ") != std::string::npos)
+    else if (regex_search(playerActionsMGR->playerActionsValidCommands,exp))
     {
         return playerActionsMGR->processCommand(formattedCmd);
     }


### PR DESCRIPTION
### MBUILD-60: Ghost Commands.
* Previously, a match is found is part of the command matches. Now, the command must be exact.


### MBUILD-80: Using tabs instead of spaces fails to split commands.

* Instead of checking for a space directly, use `isspace()` from ctype to search for all kinds of whitespace.

### How to test:
Instead of using spaces try tabs. Addtionally try mixing tabs and spaces.

Also, type in parts of valid word.
* Example: consume → sume