### PR TITLE
MBUILD-23-Time-Passes-When-Player-Travels

### DIFF
--- a/AdventureGame/Location.cpp
+++ b/AdventureGame/Location.cpp
@@ -283,8 +283,8 @@ int locationManager::getCurrentTime()
 // Updates the current Location to a new Location
 void locationManager::updateCurrentLocation(Location* newLocation)
 {
-	updateCurrentTime();
 	currentLocation = newLocation;
+	updateCurrentTime();
 	currentLocation->printLocation();
 	currentLocation->justVisitedRoom();
 	if (currentLocation->hasAttribute(Location::INSTANT_KILL_ROOM))

--- a/AdventureGame/Location.cpp
+++ b/AdventureGame/Location.cpp
@@ -149,7 +149,6 @@ bool locationManager::processCommand(vector<string> args)
 		else
 		{
 			// Move Player to the new location and print out its description
-			updateCurrentTime();
 			updateCurrentLocation(currentLocation->checkAdjacent(arg0Direction));
 			return true;
 		}
@@ -174,7 +173,6 @@ bool locationManager::processCommand(vector<string> args)
 				}
 				else // user direction has a room connected 
 				{
-					updateCurrentTime();
 					updateCurrentLocation(currentLocation->checkAdjacent(arg1Direction));
 					return true;
 				}
@@ -252,15 +250,8 @@ string Location::timeDescription = "The sun is high in the sky...";
 
 void locationManager::updateCurrentTime()
 {
-	switch (currentTime)
-	{
-		case 23:
-			currentTime = 0;
-		break;
-
-		default:
-			currentTime++;
-	}
+	// Increments current time by 1, unless it is 24, then goes back to 0 for a new day
+	currentTime = ++currentTime % 24;
 
 	switch (currentTime)
 	{
@@ -292,6 +283,7 @@ int locationManager::getCurrentTime()
 // Updates the current Location to a new Location
 void locationManager::updateCurrentLocation(Location* newLocation)
 {
+	updateCurrentTime();
 	currentLocation = newLocation;
 	currentLocation->printLocation();
 	currentLocation->justVisitedRoom();

--- a/AdventureGame/Location.cpp
+++ b/AdventureGame/Location.cpp
@@ -106,6 +106,7 @@ void Location::printLocation()
 			PrintDisplay::flush();
 		}
 	}
+	cout << timeDescription << endl;
 
 }
 
@@ -148,6 +149,7 @@ bool locationManager::processCommand(vector<string> args)
 		else
 		{
 			// Move Player to the new location and print out its description
+			updateCurrentTime();
 			updateCurrentLocation(currentLocation->checkAdjacent(arg0Direction));
 			return true;
 		}
@@ -172,6 +174,7 @@ bool locationManager::processCommand(vector<string> args)
 				}
 				else // user direction has a room connected 
 				{
+					updateCurrentTime();
 					updateCurrentLocation(currentLocation->checkAdjacent(arg1Direction));
 					return true;
 				}
@@ -240,6 +243,51 @@ int Location::getLocationID()
 
 // Initializes the current Location
 Location* locationManager::currentLocation = currentLocation = nullptr;
+
+// Initializes the current Time
+int locationManager::currentTime = 8;
+
+// Initializes the time description
+string Location::timeDescription = "The sun is high in the sky...";
+
+void locationManager::updateCurrentTime()
+{
+	switch (currentTime)
+	{
+		case 23:
+			currentTime = 0;
+		break;
+
+		default:
+			currentTime++;
+	}
+
+	switch (currentTime)
+	{
+	case 6:
+		getCurrentLocation()->setTimeDescription("The sun is rising...");
+		break;
+	case 7:
+		getCurrentLocation()->setTimeDescription("The sun is high in the sky...");
+		break;
+	case 18:
+		getCurrentLocation()->setTimeDescription("The sun is setting...");
+		break;
+	case 19:
+		getCurrentLocation()->setTimeDescription("It's dark, and the moon is high in the sky...");
+		break;
+	}
+}
+
+void Location::setTimeDescription(string desc)
+{
+	timeDescription = desc;
+}
+
+int locationManager::getCurrentTime()
+{
+	return currentTime;
+}
 
 // Updates the current Location to a new Location
 void locationManager::updateCurrentLocation(Location* newLocation)

--- a/AdventureGame/Location.h
+++ b/AdventureGame/Location.h
@@ -118,6 +118,8 @@ public:
 	int getLocationID();
 
 	bool hasAttribute(roomAttributes);
+
+	static void setTimeDescription(string);
 	
 #ifdef GTESTING
 public:
@@ -134,6 +136,7 @@ private:
 	void initializeAttribMap();
 	string description;
 	string altDescription;
+	static string timeDescription;
 	Location* locationConnections[6];
 	// When the player can't go in a direction.		
 };
@@ -149,6 +152,8 @@ public:
 	static string getValidCommands();
 	static Location* getCurrentLocation();
 	static void updateCurrentLocation(Location*);
+	static void updateCurrentTime();
+	static int getCurrentTime();
 	// Initialize map of location pointers with location ID integers
 	static map<int, Location*> locationMap;
 	/// @brief Processes Location-based commands
@@ -164,5 +169,7 @@ private:
 	const static string directionStrings[6];
 	static fileParse::mapFile map;
 	static fileParse::mapDescFile mapDesc;
+	// Current time is read in military time 0 - 23:59, in hourly increments
+	static int currentTime;
 };
 #endif // !LOCATION_H

--- a/AdventureGame/Location.h
+++ b/AdventureGame/Location.h
@@ -152,7 +152,9 @@ public:
 	static string getValidCommands();
 	static Location* getCurrentLocation();
 	static void updateCurrentLocation(Location*);
+	/// @brief Increments the current time by a constant interval
 	static void updateCurrentTime();
+	/// @return The current world time
 	static int getCurrentTime();
 	// Initialize map of location pointers with location ID integers
 	static map<int, Location*> locationMap;

--- a/AdventureTimeTesting/AdventureTimeTesting.vcxproj
+++ b/AdventureTimeTesting/AdventureTimeTesting.vcxproj
@@ -62,7 +62,7 @@
       <SubSystem>Console</SubSystem>
     </Link>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir) $(OutDir) map.mbm map.mbd
+      <Command>robocopy "$(SolutionDir) " "$(OutDir) " map.mbm map.mbd
 if %errorlevel% leq 1 exit 0 else exit %errorlevel%
 
 </Command>
@@ -85,7 +85,7 @@ if %errorlevel% leq 1 exit 0 else exit %errorlevel%
       <SubSystem>Console</SubSystem>
     </Link>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir) $(OutDir) map.mbm map.mbd
+      <Command>robocopy "$(SolutionDir) " "$(OutDir) " map.mbm map.mbd
 if %errorlevel% leq 1 exit 0 else exit %errorlevel%
 
 </Command>
@@ -109,7 +109,7 @@ if %errorlevel% leq 1 exit 0 else exit %errorlevel%
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir) $(OutDir) map.mbm map.mbd
+      <Command>robocopy "$(SolutionDir) " "$(OutDir) " map.mbm map.mbd
 if %errorlevel% leq 1 exit 0 else exit %errorlevel%
 
 </Command>
@@ -133,7 +133,7 @@ if %errorlevel% leq 1 exit 0 else exit %errorlevel%
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
     </Link>
     <CustomBuildStep>
-      <Command>robocopy $(SolutionDir) $(OutDir) map.mbm map.mbd
+      <Command>robocopy "$(SolutionDir) " "$(OutDir) " map.mbm map.mbd
 if %errorlevel% leq 1 exit 0 else exit %errorlevel%
 
 </Command>

--- a/AdventureTimeTesting/test.cpp
+++ b/AdventureTimeTesting/test.cpp
@@ -18,7 +18,40 @@ namespace
     {
         locationManager::stringToDirection("north");
         //EXPECT_EQ(locationManager::stringToDirection("north"),cardinalDirection::North);
-    } 
+    }
+
+    TEST(TimePassTest, cycle)
+    {
+        int start = locationManager::getCurrentTime();
+        Location* temp = locationManager::getCurrentLocation();
+        for (int i = 0; i <= 11; i++)
+        {
+            locationManager::updateCurrentLocation(temp->checkAdjacent(North));
+            locationManager::updateCurrentLocation(temp->checkAdjacent(South));
+        }
+        int end = locationManager::getCurrentTime();
+        EXPECT_TRUE(start == end);
+    }
+
+    TEST(TimePassTest, IsCycle24hours)
+    {
+        int start = locationManager::getCurrentTime();
+        int steps = 0;
+        Location* temp = locationManager::getCurrentLocation();
+        do
+        {
+            if (steps % 2 == 0)
+            {
+                locationManager::updateCurrentLocation(temp->checkAdjacent(North));
+            }
+            if (steps % 2 == 1)
+            {
+                locationManager::updateCurrentLocation(temp->checkAdjacent(South));
+            }
+            steps++;
+        } while (locationManager::getCurrentTime() != start);
+        EXPECT_TRUE(steps == 24);
+    }
 
     class HitTest : public testing::Test {
         protected:


### PR DESCRIPTION
Created new static member variables for Location & LocationManager, as well as appropriate getters/setters. Time is incremented whenever the player moves and they can see the time whenever the location description is printed