### PR TITLE
MBUILD-28 Command Logger and Backtracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -438,3 +438,6 @@ FodyWeavers.xsd
 # Build Files (For John)
 AdventureGame-out.dSYM
 AdventureGame-out
+
+# Generated files during playthrough
+command_history.txt

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -38,6 +38,7 @@ using namespace std;
 int main()
 {    
 #ifndef _WIN32
+#ifndef GTESTING
     // Curses initalization.
 
     initscr();                    // Start curses
@@ -47,6 +48,7 @@ int main()
     cout << "\033[?47l"<<flush;   // Normal Screen Buffer
     cout << "\033[?20l"<<flush;   // New line
     cout << "\033[?2006h"<<flush; // Enable readline newline pasting
+#endif //GTESTING
 #else
     // Set output mode to handle virtual terminal sequences,
     // From https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -33,6 +33,19 @@
 
 using namespace std;
 
+#ifdef _WIN32
+// https://stackoverflow.com/questions/23471873/change-console-code-page-in-windows-c/55171823#55171823
+class UTF8CodePage {
+public:
+    UTF8CodePage() : m_old_code_page(::GetConsoleOutputCP()) {
+        ::SetConsoleOutputCP(CP_UTF8);
+    }
+    ~UTF8CodePage() { ::SetConsoleOutputCP(m_old_code_page); }
+
+private:
+    UINT m_old_code_page;
+};
+#endif // _WIN32
 
 
 int main()
@@ -50,6 +63,9 @@ int main()
     cout << "\033[?2006h"<<flush; // Enable readline newline pasting
 #endif //GTESTING
 #else
+    UTF8CodePage use;
+   
+    PrintDisplay::no_effect_flush();
     // Set output mode to handle virtual terminal sequences,
     // From https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
     HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -163,7 +163,7 @@ int main()
         } while (validInput == false);
         
         // If there is no history, or the most recent command is not the newest one..
-        if (PrintDisplay::commandHistory.empty() == true)
+        if (PrintDisplay::commandHistory.empty() == true || PrintDisplay::commandHistory[0] != command)
         {
             // Add it to the history.
             PrintDisplay::commandHistory.insert(PrintDisplay::commandHistory.begin(),command);   
@@ -173,15 +173,17 @@ int main()
 
     locationManager::deinit();
 
+    // Save the commands to a file.
     ofstream cmdHistoryFile;
     cmdHistoryFile.open("command_history.txt");
     cmdHistoryFile << starttime << "\n";
-    for (uint64_t i = 0; i< PrintDisplay::commandHistory.size(); i++)
+    for (uint64_t i = 0; i< PrintDisplay::logCommandVector.size(); i++)
     {
-        cmdHistoryFile << PrintDisplay::commandHistory[PrintDisplay::commandHistory.size()-1-i] << "\n";
+        cmdHistoryFile << PrintDisplay::logCommandVector[PrintDisplay::logCommandVector.size()-1-i] << "\n";
     }
     cmdHistoryFile.close();
     PrintDisplay::commandHistory.clear();
+    PrintDisplay::logCommandVector.clear();
 #ifndef _WIN32
     // End curses control. 
     endwin();

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -8,6 +8,17 @@
 #include <istream>
 #include <ctime>
 #include <random>
+#include <stdio.h>
+
+#include <thread>
+#include <chrono>
+
+#ifndef WIN32
+#include <ncurses.h>
+#else
+#include <condio.h>
+#define getch() _getch()
+#endif
 
 #include "Location.h"
 #include "PlayerActions.h"
@@ -26,6 +37,17 @@ using namespace std;
 
 int main()
 {
+    vector<string> commandHistory;
+    #ifndef WIN32
+    initscr();
+    keypad(stdscr, TRUE);
+    noecho();
+    scrollok(stdscr, TRUE);
+    cout << "\033[?47l"<<flush; // Normal Screen Buffer
+    cout << "\033[?20l"<<flush; // New line
+    cout << "\033[?2006h"<<flush;
+    #endif
+
     srand(time(0));
     if (locationManager::init() == false || NPCManager::init() == false)
     {
@@ -47,10 +69,13 @@ int main()
     ContextParser CP(&userInventory,&playeract);
     bool validInput;
     bool stay = true;
+    int indexOfHistory;
     do
     {
         do
         {
+            command = ""; // The comamnd string
+            indexOfHistory = -1; // The index the history is on.
             if (playeract.thePlayerIsDead())
             {
                 PrintDisplay::custom_cout << "\nYOU DID NOT SURVIVE!\n";
@@ -63,8 +88,174 @@ int main()
             }
             PrintDisplay::custom_cout << "\nWhat would you like to do?\n> ";
             PrintDisplay::no_effect_flush();
+
+            #ifndef WIN32
+            char ch = 0; // The character the user entered.
+            int interator = -1;
+            // The following is complicated. Happy reading!
+            while (ch != '\n')
+            {
+                // The user types a character
+                ch = getch();
+    
+                // Delay the terminal for about 10ms
+                this_thread::sleep_for(chrono::milliseconds(10));
+                if (ch == '\xff') // Bad character, ignore.
+                {
+                    continue;
+                }
+
+                if (ch == '\x7f') // Captured backspace
+                {
+                     // Already at the front of string, don't do anything.
+                    if (interator == -1)
+                    {
+                        continue;
+                    }
+                    // Move the cursor back
+                    ch = '\b';
+                    PrintDisplay::custom_cout << ch;
+                    PrintDisplay::no_effect_flush();
+
+                    // Get terminal cordinates (needs to be changed)
+                    int x,y;
+                    getyx(stdscr,y,x);
+                    //Delete line
+                    mvdelch(y,x);
+                    command.erase(command.begin()+(interator));
+                    interator--;
+                    continue;
+                }
+                else if (ch == '\x04') // Left arrow key
+                {
+                    // Ignore if at the start of the string.
+                    if (interator == -1)
+                    {
+                        continue;
+                    }
+                    // Move cursor back.
+                    ch = '\b';
+                    PrintDisplay::custom_cout << ch;
+                    PrintDisplay::no_effect_flush();
+                    interator--;
+                    continue;
+                }
+                else if (ch == '\x05') // Right arrow key
+                {
+                    // Ignore if at the end of the string.
+                    if (interator == command.size() -1)
+                    {
+                        continue;
+                    }
+                    // "move" cursor to right
+                    // Aka, overwrite letter at new position.
+                    PrintDisplay::custom_cout << command[++interator];
+                    PrintDisplay::no_effect_flush();
+                    continue;
+                }
+                else if (ch == '\x03') // Up arrow key
+                {
+                    if (commandHistory.size() == 0)// No commands, ignore
+                    {
+                        // Bell, should play sound.
+                        cout << '\a' <<flush;
+                        continue;
+                    }
+                    else if (commandHistory.size()-1 == indexOfHistory) // End of history, ignore
+                    {
+                        // Bell, should play sound.
+                        cout << '\a' <<flush;
+                        continue;
+                    }
+                    //TODO index bounds check
+                    command = commandHistory[++indexOfHistory];
+
+                    // Clear entire line, and reprint command.
+                    cout << "\033[2K\r"<<flush;
+                    PrintDisplay::custom_cout << "> " << command;
+                    PrintDisplay::no_effect_flush();
+                    interator = command.size()-1;
+                    continue;
+                }
+                else if (ch == '\x02') // Down arrow key
+                {
+                    // If the index is less than or equal to 0
+                    if (indexOfHistory <= 0)
+                    {
+                        if (command.empty() == true) // Empty command, warn user.
+                        {
+                            cout << '\a' <<flush;
+                            indexOfHistory = -1;
+                            continue;
+                        }
+                        command="";
+                    }
+                    else
+                    {
+                        // Get the next recent command in history.
+                        command = commandHistory[--indexOfHistory];
+                    }
+                    // Clear entire line, and reprint command.
+                    cout << "\033[2K\r" << flush;
+                    PrintDisplay::custom_cout << "> " << command;
+                    PrintDisplay::no_effect_flush();
+                    interator = command.size()-1;
+                    continue;
+
+                }
+
+                if (ch != '\n') // Ignore all new lines, acts as return.
+                {
+                    PrintDisplay::custom_cout << ch;
+                }
+
+                // Insert character to command.
+                command.insert(command.begin()+(++interator),ch);
+                
+                // If the cursor is not the end of the string...
+                // incert the character at the string.
+                // AKA: print character, then print the rest of the string.
+                int temp = interator;
+                bool checkMove = temp<(command.size()-1);
+                int move_count = -1;
+
+                // While we are not at the end of the spring:
+                while (temp<(command.size()-1))
+                {
+                    PrintDisplay::custom_cout << command[++temp];
+                    PrintDisplay::no_effect_flush();
+                    move_count++;
+                }
+                // Return cursor to original position if needed.
+                if (checkMove && ch != '\n')
+                {
+                    for (;move_count>=0;move_count--)
+                    {
+                        PrintDisplay::custom_cout << '\b';
+                        PrintDisplay::no_effect_flush();
+                    }
+                }
+                PrintDisplay::no_effect_flush();
+
+                // If the user types in a new line
+                // AKA: submit command
+                if (ch == '\n')
+                {
+                    // Print the new line
+                    PrintDisplay::custom_cout << ch;
+                    PrintDisplay::no_effect_flush();
+                    // Print carriage return.
+                    PrintDisplay::custom_cout << "\r";
+                    PrintDisplay::no_effect_flush();
+                }
+                PrintDisplay::no_effect_flush();
+            }
+            // Remove the new line, we don't want it.
+            command.replace(command.find('\n'),1,"");
+            #else
             getline(cin, command);
             cin.clear();
+            #endif
             // This is temporary, and needs to have CP logic
             if (command == "quit")
             {
@@ -74,10 +265,20 @@ int main()
             // TODO: how do we restart the game? not make it a harsh exit of the game 
             validInput = CP.interpretCommand(command);
         } while (validInput == false);
+        
+        // If there is no history, or the most recent command is not the newest one..
+        if (commandHistory.size() == 0 || commandHistory[0] != command)
+        {
+            // Add it to the history.
+            commandHistory.insert(commandHistory.begin(),command);   
+        }
         playeract.decrementMovingHigh();
     } while (stay);
 
     locationManager::deinit();
+    #ifndef WIN32
+    endwin();
+    #endif    
 }
 
 // Run program: Ctrl + F5 or Debug > Start Without Debugging menu

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -109,8 +109,8 @@ int main()
         return -1;
     }
 #endif
-
-    srand(time(0));
+    time_t starttime = time(0);
+    srand(starttime);
     if (locationManager::init() == false || NPCManager::init() == false)
     {
         locationManager::deinit();
@@ -163,7 +163,7 @@ int main()
         } while (validInput == false);
         
         // If there is no history, or the most recent command is not the newest one..
-        if (PrintDisplay::commandHistory.empty() == true || PrintDisplay::commandHistory[0] != command)
+        if (PrintDisplay::commandHistory.empty() == true)
         {
             // Add it to the history.
             PrintDisplay::commandHistory.insert(PrintDisplay::commandHistory.begin(),command);   
@@ -172,6 +172,15 @@ int main()
     } while (stay);
 
     locationManager::deinit();
+
+    ofstream cmdHistoryFile;
+    cmdHistoryFile.open("command_history.txt");
+    cmdHistoryFile << starttime << "\n";
+    for (uint64_t i = 0; i< PrintDisplay::commandHistory.size(); i++)
+    {
+        cmdHistoryFile << PrintDisplay::commandHistory[PrintDisplay::commandHistory.size()-1-i] << "\n";
+    }
+    cmdHistoryFile.close();
     PrintDisplay::commandHistory.clear();
 #ifndef _WIN32
     // End curses control. 

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -86,7 +86,7 @@ int main()
             }
             PrintDisplay::custom_cout << "\nWhat would you like to do?\n> ";
             PrintDisplay::no_effect_flush();
-            command = PrintDisplay::inputValidation();
+            command = PrintDisplay::inputValidation(true);
 
             /*#ifndef WIN32
             char ch = 0; // The character the user entered.

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -36,8 +36,7 @@ using namespace std;
 #include "PrintDisplay.h"
 
 int main()
-{
-    vector<string> commandHistory;
+{    
     #ifndef WIN32
     initscr();
     keypad(stdscr, TRUE);
@@ -74,7 +73,6 @@ int main()
     {
         do
         {
-            command = ""; // The comamnd string
             indexOfHistory = -1; // The index the history is on.
             if (playeract.thePlayerIsDead())
             {
@@ -88,8 +86,9 @@ int main()
             }
             PrintDisplay::custom_cout << "\nWhat would you like to do?\n> ";
             PrintDisplay::no_effect_flush();
+            command = PrintDisplay::inputValidation();
 
-            #ifndef WIN32
+            /*#ifndef WIN32
             char ch = 0; // The character the user entered.
             int interator = -1;
             // The following is complicated. Happy reading!
@@ -107,23 +106,20 @@ int main()
 
                 if (ch == '\x7f') // Captured backspace
                 {
-                     // Already at the front of string, don't do anything.
                     if (interator == -1)
                     {
                         continue;
-                    }
-                    // Move the cursor back
-                    ch = '\b';
-                    PrintDisplay::custom_cout << ch;
-                    PrintDisplay::no_effect_flush();
-
-                    // Get terminal cordinates (needs to be changed)
-                    int x,y;
-                    getyx(stdscr,y,x);
-                    //Delete line
-                    mvdelch(y,x);
-                    command.erase(command.begin()+(interator));
+                    }                  
+                    command.erase(command.begin()+(interator)); 
                     interator--;
+                    cout << "\033[2K\r"<<flush;
+                    PrintDisplay::custom_cout << "> " << command;
+                    PrintDisplay::no_effect_flush();
+                    for (int a = command.size()-2; a>=interator; a--)
+                    {
+                        PrintDisplay::custom_cout << '\b';
+                        PrintDisplay::no_effect_flush();
+                    }
                     continue;
                 }
                 else if (ch == '\x04') // Left arrow key
@@ -252,10 +248,11 @@ int main()
             }
             // Remove the new line, we don't want it.
             command.replace(command.find('\n'),1,"");
-            #else
-            getline(cin, command);
-            cin.clear();
-            #endif
+            
+            #else*/
+            //getline(cin, command);
+            //cin.clear();
+            //#endif
             // This is temporary, and needs to have CP logic
             if (command == "quit")
             {
@@ -267,10 +264,10 @@ int main()
         } while (validInput == false);
         
         // If there is no history, or the most recent command is not the newest one..
-        if (commandHistory.size() == 0 || commandHistory[0] != command)
+        if (PrintDisplay::commandHistory.size() == 0 || PrintDisplay::commandHistory[0] != command)
         {
             // Add it to the history.
-            commandHistory.insert(commandHistory.begin(),command);   
+            PrintDisplay::commandHistory.insert(PrintDisplay::commandHistory.begin(),command);   
         }
         playeract.decrementMovingHigh();
     } while (stay);

--- a/AdventureGame/AdventureGame.cpp
+++ b/AdventureGame/AdventureGame.cpp
@@ -56,12 +56,14 @@ int main()
     if (hOut == INVALID_HANDLE_VALUE)
     {
         cout << "An error occurred, please try rerunning the app." << endl;
+        PrintDisplay::pause();
         return false;
     }
     HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
     if (hIn == INVALID_HANDLE_VALUE)
     {
         cout << "An error occurred, please try rerunning the app." << endl;
+        PrintDisplay::pause();
         return false;
     }
 
@@ -70,11 +72,13 @@ int main()
     if (!GetConsoleMode(hOut, &dwOriginalOutMode))
     {
         cout << "An error occurred, please try rerunning the app." << endl;
+        PrintDisplay::pause();
         return false;
     }
     if (!GetConsoleMode(hIn, &dwOriginalInMode))
     {
         cout << "An error occurred, please try rerunning the app." << endl;
+        PrintDisplay::pause();
         return false;
     }
 
@@ -91,6 +95,7 @@ int main()
         {
             // Failed to set any VT mode, can't do anything here.
             cout << "An error occurred, please try rerunning the app." << endl;
+            PrintDisplay::pause();
             return -1;
         }
     }
@@ -100,6 +105,7 @@ int main()
     {
         // Failed to set VT input mode, can't do anything here.
         cout << "An error occurred, please try rerunning the app." << endl;
+        PrintDisplay::pause();
         return -1;
     }
 #endif
@@ -108,6 +114,7 @@ int main()
     if (locationManager::init() == false || NPCManager::init() == false)
     {
         locationManager::deinit();
+        PrintDisplay::pause();
         return 1;
     }
 

--- a/AdventureGame/ContextParser.cpp
+++ b/AdventureGame/ContextParser.cpp
@@ -94,6 +94,22 @@ bool ContextParser::interpretCommand(string unfilteredCmd)
 
 bool ContextParser::yesNoPrompt()
 {
+    string command;
+    do
+    {
+        PrintDisplay::custom_cout << "\nYes or no?\n> ";
+        PrintDisplay::no_effect_flush();
+        command = PrintDisplay::inputValidation(false);
+        if (command == "yes" || command == "y" || command == "ye")
+        {
+            return CPResponse::Response::YES;
+        }
+        else if (command == "no" || command == "n")
+        {
+            return CPResponse::Response::NO;
+        }
+    }while (true);
+    /*
     string unfilteredCommand;
     string command;
     bool validInput = false;
@@ -123,5 +139,5 @@ bool ContextParser::yesNoPrompt()
         {
             return CPResponse::Response::NO;
         }
-    } while (true);
+    } while (true);*/
 }

--- a/AdventureGame/ContextParser.cpp
+++ b/AdventureGame/ContextParser.cpp
@@ -99,7 +99,7 @@ bool ContextParser::yesNoPrompt()
     {
         PrintDisplay::custom_cout << "\nYes or no?\n> ";
         PrintDisplay::no_effect_flush();
-        command = PrintDisplay::inputValidation(false);
+        command = PrintDisplay::inputValidation(true);
         if (command == "yes" || command == "y" || command == "ye")
         {
             return CPResponse::Response::YES;

--- a/AdventureGame/ContextParser.cpp
+++ b/AdventureGame/ContextParser.cpp
@@ -102,10 +102,12 @@ bool ContextParser::yesNoPrompt()
         command = PrintDisplay::inputValidation(true);
         if (command == "yes" || command == "y" || command == "ye")
         {
+            PrintDisplay::commandHistory.insert(PrintDisplay::commandHistory.begin(), command);
             return CPResponse::Response::YES;
         }
         else if (command == "no" || command == "n")
         {
+            PrintDisplay::commandHistory.insert(PrintDisplay::commandHistory.begin(), command);
             return CPResponse::Response::NO;
         }
     }while (true);

--- a/AdventureGame/Location.cpp
+++ b/AdventureGame/Location.cpp
@@ -107,7 +107,8 @@ void Location::printLocation()
 			PrintDisplay::flush();
 		}
 	}
-	cout << timeDescription << endl;
+	PrintDisplay::custom_cout << timeDescription << endl;
+	PrintDisplay::flush();
 
 }
 

--- a/AdventureGame/Location.cpp
+++ b/AdventureGame/Location.cpp
@@ -389,6 +389,8 @@ bool locationManager::init()
 
     // Set the starting location to the player location and print the description
 	locationManager::currentLocation = locationManager::locationMap[1];
+	descBytes.clear();
+	mapBytes.clear();
 	return true;
 }
 

--- a/AdventureGame/PlayerActions.cpp
+++ b/AdventureGame/PlayerActions.cpp
@@ -193,6 +193,7 @@ bool PlayerActions::playAgain()
         // Goodbye quote
         PrintDisplay::custom_cout << "\nThe difference between the master and the student is that the master has failed far more times than the student.\n";
         PrintDisplay::no_effect_flush();
+        PrintDisplay::pause();
     }
     return runItBack;
 }

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -39,6 +39,7 @@ using namespace std;
 
 std::ostringstream PrintDisplay::custom_cout;
 std::vector<std::string> PrintDisplay::commandHistory;
+std::vector<std::string> PrintDisplay::logCommandVector;
 
 char readCH()
 {
@@ -339,6 +340,9 @@ string PrintDisplay::inputValidation(bool noHistory)
 
     // Remove the new line, we don't want it.
     command.replace(command.find('\n'),1,"");
+
+    // Log the command to the text file, even if invalid.
+    PrintDisplay::logCommandVector.insert(PrintDisplay::logCommandVector.begin(), command);
     return command;
 }
 

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <thread>
 #include <chrono>
+#include <regex>
 
 #ifdef GTESTING
 std::string PrintDisplay::GT_inStr = "";
@@ -64,11 +65,11 @@ void printToScreen(string str)
 {
 #if !defined _WIN32 && !defined GTESTING
     refresh();
-    printw("%s", str.c_str());
-    refresh();
-#else
-    std::cout << str << std::flush;
+    string temp(str);
+    str.clear();
+    regex_replace(back_inserter(str),temp.begin(),temp.end(),regex("\\n"),"\n\r");
 #endif
+    std::cout << str << std::flush;
 }
 
 void PrintDisplay::common_flush(bool forceNormal)
@@ -109,11 +110,7 @@ void clear(const string &command)
 {
     PrintDisplay::custom_cout << "\r";
     PrintDisplay::no_effect_flush();
-#ifndef _WIN32
-    clrtobot();
-#else
     cout << "\033[0J" << std::flush;
-#endif  
     PrintDisplay::custom_cout << "> " << command;
     PrintDisplay::no_effect_flush();
 }
@@ -331,9 +328,6 @@ string PrintDisplay::inputValidation(bool noHistory)
             // Print the new line
             PrintDisplay::custom_cout << ch;
             PrintDisplay::no_effect_flush();
-            // Print carriage return.
-            PrintDisplay::custom_cout << "\r";
-            PrintDisplay::no_effect_flush();
         }
     }
     // At this point, the user wants to submit a command.
@@ -350,7 +344,7 @@ void PrintDisplay::pause()
 {
     PrintDisplay::custom_cout << "\nPress any key to continue . . .";
     PrintDisplay::no_effect_flush();
-    getch();
+    readCH();
     PrintDisplay::custom_cout << "\n";
     PrintDisplay::no_effect_flush();
 }

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -1,11 +1,11 @@
 #include "PrintDisplay.h"
 #include "CommonGameObjects.h"
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <ncurses.h>
 #else
-#include <condio.h>
-#define getch() _getch()
+#include <conio.h>
+#define getch() _getwch()
 #endif
 #include <iostream>
 #include <string>
@@ -28,32 +28,30 @@ void PrintDisplay::no_effect_flush()
     PrintDisplay::common_flush(true);
 }
 
+void printToScreen(string str)
+{
+#ifndef _WIN32
+    refresh();
+    printw("%s", str.c_str());
+    refresh();
+#else
+    std::cout << str << std::flush;
+#endif
+}
+
 void PrintDisplay::common_flush(bool forceNormal)
 {
         string str(custom_cout.str());
         if (CommonGameObjects::PAManager == nullptr || forceNormal == true) // If we are printing without PA, just print the string
         {
-            #ifndef WIN32
-            refresh();
-            printw("%s",str.c_str());
-            refresh();
-            #else
-            std::cout << str << std::flush;
-            #endif
-            
+            printToScreen(str);            
             custom_cout.str("");
             return;
         }
 
         if (CommonGameObjects::PAManager->isThePlayerHigh() == false)
         {
-            #ifndef WIN32
-            refresh();
-            printw("%s",str.c_str());
-            refresh();
-            #else
-            std::cout << str << std::flush;
-            #endif
+            printToScreen(str);
         } 
         else
         {
@@ -69,67 +67,89 @@ void PrintDisplay::common_flush(bool forceNormal)
                 }
                 std::swap(str[a], str[b]);
             }
-            #ifndef WIN32
-            refresh();
-            printw("%s",str.c_str());
-            refresh();
-            #else
-            std::cout << str << std::flush;
-            #endif
+            printToScreen(str);
         }
         // Clear the stringstream
         custom_cout.str("");
 }
 
+void clear(const string &command)
+{
+    PrintDisplay::custom_cout << "\r";
+    PrintDisplay::no_effect_flush();
+#ifndef _WIN32
+    clrtobot();
+#else
+    cout << "\033[0J" << std::flush;
+#endif  
+    PrintDisplay::custom_cout << "> " << command;
+    PrintDisplay::no_effect_flush();
+}
+
 string PrintDisplay::inputValidation(bool noHistory)
 {
-    string command;
-    int indexOfHistory = -1;
+    string command; // The command that user typed
+    int indexOfHistory = -1; // The index of the commandHistory vector
     char ch = 0; // The character the user entered.
-    int interator = -1;
-    // The following is complicated. Happy reading!
-    while (ch != '\n')
+    int interator = -1; // Where the cursor should be
+
+    /* The following is VERY complicated. Happy reading! */
+
+    while (ch != '\n') // New lines indincate the end of the input.
     {
+        bool isScanCode = false; // For windows Only.
+
         // The user types a character
         ch = getch();
+
         if (ch == '\xff') // Bad character, ignore.
         {
             continue;
         }
 
-        if (ch == '\x7f') // Captured backspace
+#ifdef _WIN32
+        else if (ch == -32) // KeyCode incoming. Catch and read next character.
         {
-            if (interator == -1)
+            isScanCode = true;
+            ch = getch(); // Should be a keycode or arrow key
+        }
+#endif
+
+#ifdef _WIN32
+        if (ch == '\b') // Captured backspace
+#else
+        if (ch == '\x7f') // Captured backspace
+#endif
+        {
+            if (interator == -1) // We are at the start of the prompt, dont do anything.
             {
                 continue;
             }                  
-            command.erase(command.begin()+(interator)); 
+            // Erase the character from the string
+            command.erase(command.begin()+interator); 
             interator--;
+
+            // Move the cursror by one character
             PrintDisplay::custom_cout << "\b";
             PrintDisplay::no_effect_flush();
 
-            cout<< "\0337" << std::flush;//Save cursor Position
-            PrintDisplay::custom_cout << "\r"; 
-            PrintDisplay::no_effect_flush();
+            cout << "\0337" << std::flush;//Save cursor Position
 
-            #ifndef WIN32
-            clrtobot();
-            #else
-            cout << "\033[0J" << std::flush;
-            #endif            
+            // Clear screen from cursor down
+            clear(command);
 
-            PrintDisplay::custom_cout << "\r"; 
-            PrintDisplay::no_effect_flush();
-
-            PrintDisplay::custom_cout << "> " << command;
-            PrintDisplay::no_effect_flush();
             cout << "\0338"<< std::flush; //Save cursor Position
             // Delay the terminal for about 10ms
             this_thread::sleep_for(chrono::milliseconds(30));
             continue;
             
         }
+#ifdef _WIN32
+        else if (ch == 'K' && isScanCode == true) // Left arrow key
+#else
+
         else if (ch == '\x04') // Left arrow key
+#endif
         {
             // Ignore if at the start of the string.
             if (interator == -1)
@@ -143,7 +163,11 @@ string PrintDisplay::inputValidation(bool noHistory)
             interator--;
             continue;
         }
+#ifdef _WIN32
+        else if (ch == 'M' && isScanCode == true) // Right arrow key
+#else
         else if (ch == '\x05') // Right arrow key
+#endif
         {
             // Ignore if at the end of the string.
             if (interator == command.size() -1)
@@ -156,43 +180,38 @@ string PrintDisplay::inputValidation(bool noHistory)
             PrintDisplay::no_effect_flush();
             continue;
         }
+#ifdef _WIN32
+        else if (ch == 'H' && isScanCode == true) // Up arrow key
+#else
         else if (ch == '\x03') // Up arrow key
+#endif
         {
-            if (noHistory == true)
+            // Ignore and warn user in case:
+            // - History is disabled
+            // - There is no history
+            // - The inter is at the last element
+            if (noHistory == true || PrintDisplay::commandHistory.empty() == true || PrintDisplay::commandHistory.size() - 1 == indexOfHistory)
             {
+                // Bell, should play sound, if not, that's fine.
                 cout << '\a' << std::flush;
                 continue;
             }
-            if (PrintDisplay::commandHistory.size() == 0)// No commands, ignore
-            {
-                // Bell, should play sound.
-                cout << '\a' << std::flush;
-                continue;
-            }
-            else if (PrintDisplay::commandHistory.size()-1 == indexOfHistory) // End of history, ignore
-            {
-                // Bell, should play sound.
-                cout << '\a' << std::flush;
-                continue;
-            }
-            //TODO index bounds check
+
+            // Set the command to the last command.
             command = PrintDisplay::commandHistory[++indexOfHistory];
 
             // Clear entire line, and reprint command.
-            #ifndef WIN32
-            PrintDisplay::custom_cout << "\r";
-            PrintDisplay::no_effect_flush();
-            clrtobot();
-            #else
-            cout << "\033[0J" << std::flush;
-            #endif  
-            PrintDisplay::custom_cout << "> " << command;
-            PrintDisplay::no_effect_flush();
+            clear(command);
             interator = command.size()-1;
             continue;
         }
+#ifdef _WIN32
+        else if (ch == 'P' && isScanCode == true) // Down arrow key
+#else
         else if (ch == '\x02') // Down arrow key
+#endif
         {
+            // History disabled, ignore.
             if (noHistory == true)
             {
                 cout << '\a' << std::flush;
@@ -201,10 +220,10 @@ string PrintDisplay::inputValidation(bool noHistory)
             // If the index is less than or equal to 0
             if (indexOfHistory <= 0)
             {
-                if (command.empty() == true) // Empty command, warn user.
+                if (command.empty() == true) // Empty command, just warn user.
                 {
                     cout << '\a' << std::flush;
-                    indexOfHistory = -1;
+                    indexOfHistory = -1; // Do this just in case.
                     continue;
                 }
                 command="";
@@ -216,25 +235,29 @@ string PrintDisplay::inputValidation(bool noHistory)
                 command = PrintDisplay::commandHistory[--indexOfHistory];
             }
             // Clear entire line, and reprint command.
-            #ifndef WIN32
-            PrintDisplay::custom_cout << "\r";
-            PrintDisplay::no_effect_flush();
-            clrtobot();
-            #else
-            cout << "\033[0J" << std::flush;
-            #endif  
-            PrintDisplay::custom_cout << "> " << command;
-            PrintDisplay::no_effect_flush();
+            clear(command);
             interator = command.size()-1;
             continue;
 
         }
-        if (command.size() >= 30 && ch != '\n')
+
+        // Mainly for Windows
+        // Windows typically uses carriage returns, we're using newlines instead.
+        if (ch == '\r')
+        {
+            ch = '\n';
+        }
+        
+        // If the command string is GEQ the max size,
+        // Let the user know.
+        // However, if the character is a new line, skip this check.
+        if (command.size() >= MAX_COMMAND_SIZE && ch != '\n')
         {
             cout << '\a' << std::flush;
             continue;
         }
-        if (ch != '\n') // Ignore all new lines, acts as return.
+
+        if (ch != '\n') // Ignore all new lines, it acts as return.
         {
             PrintDisplay::custom_cout << ch;
         }
@@ -266,6 +289,7 @@ string PrintDisplay::inputValidation(bool noHistory)
             }
         }
 
+        // Redundant flush JIC
         PrintDisplay::no_effect_flush();
 
         // If the user types in a new line
@@ -279,8 +303,9 @@ string PrintDisplay::inputValidation(bool noHistory)
             PrintDisplay::custom_cout << "\r";
             PrintDisplay::no_effect_flush();
         }
-        PrintDisplay::no_effect_flush();
     }
+    // At this point, the user wants to submit a command.
+
     // Remove the new line, we don't want it.
     command.replace(command.find('\n'),1,"");
     return command;

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -12,11 +12,42 @@
 #include <thread>
 #include <chrono>
 
+#ifdef GTESTING
+std::string PrintDisplay::GT_inStr = "";
+
+void PrintDisplay::GT_setString(std::string s)
+{
+    // Load the string into the "buffer"
+    GT_inStr = s;
+}
+char PrintDisplay::GT_getch()
+{
+    if (GT_inStr.empty() == false)
+    {
+        // Get the first character from the "buffer"
+        char r = GT_inStr[0];
+        // Delete the first character from the "buffer"
+        GT_inStr.erase(GT_inStr.begin());
+        return r;
+    }
+    return '\xff'; // No characters left in the "buffer"
+}
+#endif
+
 
 using namespace std;
 
 std::ostringstream PrintDisplay::custom_cout;
 std::vector<std::string> PrintDisplay::commandHistory;
+
+char readCH()
+{
+#ifdef GTESTING
+        return PrintDisplay::GT_getch();
+#else
+        return getch();
+#endif
+}
 
 void PrintDisplay::flush()
 {
@@ -30,7 +61,7 @@ void PrintDisplay::no_effect_flush()
 
 void printToScreen(string str)
 {
-#ifndef _WIN32
+#if !defined _WIN32 && !defined GTESTING
     refresh();
     printw("%s", str.c_str());
     refresh();
@@ -100,7 +131,7 @@ string PrintDisplay::inputValidation(bool noHistory)
         bool isScanCode = false; // For windows Only.
 
         // The user types a character
-        ch = getch();
+        ch = readCH();
 
         if (ch == '\xff') // Bad character, ignore.
         {
@@ -111,7 +142,7 @@ string PrintDisplay::inputValidation(bool noHistory)
         else if (ch == -32) // KeyCode incoming. Catch and read next character.
         {
             isScanCode = true;
-            ch = getch(); // Should be a keycode or arrow key
+            ch = readCH(); // Should be a keycode or arrow key
         }
 #endif
 

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -7,10 +7,16 @@
 #include <condio.h>
 #define getch() _getch()
 #endif
+#include <iostream>
+#include <string>
+#include <thread>
+#include <chrono>
+
 
 using namespace std;
 
 std::ostringstream PrintDisplay::custom_cout;
+std::vector<std::string> PrintDisplay::commandHistory;
 
 void PrintDisplay::flush()
 {
@@ -70,6 +76,172 @@ void PrintDisplay::common_flush(bool forceNormal)
         }
         // Clear the stringstream
         custom_cout.str("");
+}
+
+string PrintDisplay::inputValidation()
+{
+    string command;
+    int indexOfHistory = -1;
+    char ch = 0; // The character the user entered.
+    int interator = -1;
+    // The following is complicated. Happy reading!
+    while (ch != '\n')
+    {
+        // The user types a character
+        ch = getch();
+
+        // Delay the terminal for about 10ms
+        this_thread::sleep_for(chrono::milliseconds(30));
+        if (ch == '\xff') // Bad character, ignore.
+        {
+            continue;
+        }
+
+        if (ch == '\x7f') // Captured backspace
+        {
+            if (interator == -1)
+            {
+                continue;
+            }                  
+            command.erase(command.begin()+(interator)); 
+            interator--;
+            cout << "\033[2K\r"<< std::flush;
+            PrintDisplay::custom_cout << "> " << command;
+            PrintDisplay::no_effect_flush();
+            for (int a = command.size()-2; a>=interator; a--)
+            {
+                PrintDisplay::custom_cout << '\b';
+                PrintDisplay::no_effect_flush();
+            }
+            continue;
+        }
+        else if (ch == '\x04') // Left arrow key
+        {
+            // Ignore if at the start of the string.
+            if (interator == -1)
+            {
+                continue;
+            }
+            // Move cursor back.
+            ch = '\b';
+            PrintDisplay::custom_cout << ch;
+            PrintDisplay::no_effect_flush();
+            interator--;
+            continue;
+        }
+        else if (ch == '\x05') // Right arrow key
+        {
+            // Ignore if at the end of the string.
+            if (interator == command.size() -1)
+            {
+                continue;
+            }
+            // "move" cursor to right
+            // Aka, overwrite letter at new position.
+            PrintDisplay::custom_cout << command[++interator];
+            PrintDisplay::no_effect_flush();
+            continue;
+        }
+        else if (ch == '\x03') // Up arrow key
+        {
+            if (PrintDisplay::commandHistory.size() == 0)// No commands, ignore
+            {
+                // Bell, should play sound.
+                cout << '\a' << std::flush;
+                continue;
+            }
+            else if (PrintDisplay::commandHistory.size()-1 == indexOfHistory) // End of history, ignore
+            {
+                // Bell, should play sound.
+                cout << '\a' << std::flush;
+                continue;
+            }
+            //TODO index bounds check
+            command = PrintDisplay::commandHistory[++indexOfHistory];
+
+            // Clear entire line, and reprint command.
+            cout << "\033[2K\r"<< std::flush;
+            PrintDisplay::custom_cout << "> " << command;
+            PrintDisplay::no_effect_flush();
+            interator = command.size()-1;
+            continue;
+        }
+        else if (ch == '\x02') // Down arrow key
+        {
+            // If the index is less than or equal to 0
+            if (indexOfHistory <= 0)
+            {
+                if (command.empty() == true) // Empty command, warn user.
+                {
+                    cout << '\a' << std::flush;
+                    indexOfHistory = -1;
+                    continue;
+                }
+                command="";
+            }
+            else
+            {
+                // Get the next recent command in history.
+                command = PrintDisplay::commandHistory[--indexOfHistory];
+            }
+            // Clear entire line, and reprint command.
+            cout << "\033[2K\r" << std::flush;
+            PrintDisplay::custom_cout << "> " << command;
+            PrintDisplay::no_effect_flush();
+            interator = command.size()-1;
+            continue;
+
+        }
+
+        if (ch != '\n') // Ignore all new lines, acts as return.
+        {
+            PrintDisplay::custom_cout << ch;
+        }
+
+        // Insert character to command.
+        command.insert(command.begin()+(++interator),ch);
+        
+        // If the cursor is not the end of the string...
+        // incert the character at the string.
+        // AKA: print character, then print the rest of the string.
+        int temp = interator;
+        bool checkMove = temp<(command.size()-1);
+        int move_count = -1;
+
+        // While we are not at the end of the spring:
+        while (temp<(command.size()-1))
+        {
+            PrintDisplay::custom_cout << command[++temp];
+            PrintDisplay::no_effect_flush();
+            move_count++;
+        }
+        // Return cursor to original position if needed.
+        if (checkMove && ch != '\n')
+        {
+            for (;move_count>=0;move_count--)
+            {
+                PrintDisplay::custom_cout << '\b';
+                PrintDisplay::no_effect_flush();
+            }
+        }
+        PrintDisplay::no_effect_flush();
+
+        // If the user types in a new line
+        // AKA: submit command
+        if (ch == '\n')
+        {
+            // Print the new line
+            PrintDisplay::custom_cout << ch;
+            PrintDisplay::no_effect_flush();
+            // Print carriage return.
+            PrintDisplay::custom_cout << "\r";
+            PrintDisplay::no_effect_flush();
+        }
+        PrintDisplay::no_effect_flush();
+    }
+    // Remove the new line, we don't want it.
+    command.replace(command.find('\n'),1,"");
+    return command;
 }
 
 

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -348,8 +348,10 @@ string PrintDisplay::inputValidation(bool noHistory)
 
 void PrintDisplay::pause()
 {
-    PrintDisplay::custom_cout << "\nPress any key to continue...\n";
+    PrintDisplay::custom_cout << "\nPress any key to continue . . .";
     PrintDisplay::no_effect_flush();
     getch();
+    PrintDisplay::custom_cout << "\n";
+    PrintDisplay::no_effect_flush();
 }
 

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -1,6 +1,13 @@
 #include "PrintDisplay.h"
 #include "CommonGameObjects.h"
 
+#ifndef WIN32
+#include <ncurses.h>
+#else
+#include <condio.h>
+#define getch() _getch()
+#endif
+
 using namespace std;
 
 std::ostringstream PrintDisplay::custom_cout;
@@ -20,14 +27,25 @@ void PrintDisplay::common_flush(bool forceNormal)
         string str(custom_cout.str());
         if (CommonGameObjects::PAManager == nullptr || forceNormal == true) // If we are printing without PA, just print the string
         {
+            #ifndef WIN32
+            printw("%s",str.c_str());
+            refresh();
+            #else
             std::cout << str << std::flush;
+            #endif
+            
             custom_cout.str("");
             return;
         }
 
         if (CommonGameObjects::PAManager->isThePlayerHigh() == false)
         {
+            #ifndef WIN32
+            printw("%s",str.c_str());
+            refresh();
+            #else
             std::cout << str << std::flush;
+            #endif
         } 
         else
         {
@@ -43,7 +61,12 @@ void PrintDisplay::common_flush(bool forceNormal)
                 }
                 std::swap(str[a], str[b]);
             }
+            #ifndef WIN32
+            printw("%s",str.c_str());
+            refresh();
+            #else
             std::cout << str << std::flush;
+            #endif
         }
         // Clear the stringstream
         custom_cout.str("");

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -149,11 +149,7 @@ string PrintDisplay::inputValidation(bool noHistory)
         }
 #endif
 
-#ifdef _WIN32
-        if (ch == '\b') // Captured backspace
-#else
-        if (ch == '\x7f') // Captured backspace
-#endif
+        if (ch == '\b' || ch == '\x7f') // Captured backspace
         {
             if (interator == -1) // We are at the start of the prompt, dont do anything.
             {
@@ -172,9 +168,9 @@ string PrintDisplay::inputValidation(bool noHistory)
             // Clear screen from cursor down
             clear(command);
 
-            cout << "\0338"<< std::flush; //Save cursor Position
+            cout << "\0338"<< std::flush; //Restore cursor Position
             // Delay the terminal for about 10ms
-            this_thread::sleep_for(chrono::milliseconds(30));
+            this_thread::sleep_for(chrono::milliseconds(20));
             continue;
             
         }

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -311,5 +311,10 @@ string PrintDisplay::inputValidation(bool noHistory)
     return command;
 }
 
-
+void PrintDisplay::pause()
+{
+    PrintDisplay::custom_cout << "\nPress any key to continue...\n";
+    PrintDisplay::no_effect_flush();
+    getch();
+}
 

--- a/AdventureGame/PrintDisplay.cpp
+++ b/AdventureGame/PrintDisplay.cpp
@@ -142,6 +142,11 @@ string PrintDisplay::inputValidation(bool noHistory)
             isScanCode = true;
             ch = readCH(); // Should be a keycode or arrow key
         }
+        else if (ch == '\x1b' && readCH() == '[') //ANSI escape code, could happen if input is very fast
+        {
+            ch = readCH();
+            isScanCode = true;
+        }
 #endif
 
 #ifdef _WIN32
@@ -174,7 +179,7 @@ string PrintDisplay::inputValidation(bool noHistory)
             
         }
 #ifdef _WIN32
-        else if (ch == 'K' && isScanCode == true) // Left arrow key
+        else if ((ch == 'D' || ch == 'K') && isScanCode == true) // Left arrow key
 #else
 
         else if (ch == '\x04') // Left arrow key
@@ -193,7 +198,7 @@ string PrintDisplay::inputValidation(bool noHistory)
             continue;
         }
 #ifdef _WIN32
-        else if (ch == 'M' && isScanCode == true) // Right arrow key
+        else if ((ch == 'C' || ch == 'M') && isScanCode == true) // Right arrow key
 #else
         else if (ch == '\x05') // Right arrow key
 #endif
@@ -210,7 +215,7 @@ string PrintDisplay::inputValidation(bool noHistory)
             continue;
         }
 #ifdef _WIN32
-        else if (ch == 'H' && isScanCode == true) // Up arrow key
+        else if ((ch == 'A' || ch == 'H') && isScanCode == true) // Up arrow key
 #else
         else if (ch == '\x03') // Up arrow key
 #endif
@@ -235,7 +240,7 @@ string PrintDisplay::inputValidation(bool noHistory)
             continue;
         }
 #ifdef _WIN32
-        else if (ch == 'P' && isScanCode == true) // Down arrow key
+        else if ((ch == 'B' || ch == 'P') && isScanCode == true) // Down arrow key
 #else
         else if (ch == '\x02') // Down arrow key
 #endif

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -31,7 +31,7 @@ public:
         /// @brief A log of the commands the player typed (for debugging).
         static std::vector<std::string> logCommandVector;
 
-        /// @brief Displays "Press any key to continue..."
+        /// @brief Displays "Press any key to continue . . ."
         static void pause();
 
 #ifdef GTESTING

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -25,8 +25,11 @@ public:
         /// @return The command in string form.
         static std::string inputValidation(bool);
 
-        /// @brief The history of the commands the player typed.
+        /// @brief The history of the commands the player typed (for the terminal).
         static std::vector<std::string> commandHistory;
+
+        /// @brief A log of the commands the player typed (for debugging).
+        static std::vector<std::string> logCommandVector;
 
         /// @brief Displays "Press any key to continue..."
         static void pause();

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -18,7 +18,7 @@ public:
         /// @brief Print the buffer to the console without effects, must be called.
         static void no_effect_flush();
 
-        static std::string inputValidation();
+        static std::string inputValidation(bool);
         static std::vector<std::string> commandHistory;
 private:
         static void common_flush(bool);

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -27,6 +27,9 @@ public:
 
         /// @brief The history of the commands the player typed.
         static std::vector<std::string> commandHistory;
+
+        /// @brief Displays "Press any key to continue..."
+        static void pause();
 private:
         static void common_flush(bool);
 };

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -3,6 +3,7 @@
 #include <streambuf>
 #include <iostream>
 #include <typeinfo>
+#include <vector>
 
 #include "PlayerActions.h"
 
@@ -16,6 +17,9 @@ public:
 
         /// @brief Print the buffer to the console without effects, must be called.
         static void no_effect_flush();
+
+        static std::string inputValidation();
+        static std::vector<std::string> commandHistory;
 private:
         static void common_flush(bool);
 };

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -30,6 +30,18 @@ public:
 
         /// @brief Displays "Press any key to continue..."
         static void pause();
+
+#ifdef GTESTING
+        static std::string GT_inStr;
+
+        /// @brief Pretends to be the string buffer for GTESTING
+        /// @param s The string to process
+        static void GT_setString(std::string s);
+
+        /// @brief Helper for GTESTING, replicates getch().
+        /// @return The character at the front of the string
+        static char GT_getch();
+#endif
 private:
         static void common_flush(bool);
 };

--- a/AdventureGame/PrintDisplay.h
+++ b/AdventureGame/PrintDisplay.h
@@ -7,6 +7,8 @@
 
 #include "PlayerActions.h"
 
+#define MAX_COMMAND_SIZE 30
+
 class PrintDisplay
 {
 public:
@@ -18,7 +20,12 @@ public:
         /// @brief Print the buffer to the console without effects, must be called.
         static void no_effect_flush();
 
+        /// @brief Handles direct input from the terminal.
+        /// @param noHistory The history should be disabled.
+        /// @return The command in string form.
         static std::string inputValidation(bool);
+
+        /// @brief The history of the commands the player typed.
         static std::vector<std::string> commandHistory;
 private:
         static void common_flush(bool);

--- a/AdventureTimeTesting/test.cpp
+++ b/AdventureTimeTesting/test.cpp
@@ -250,18 +250,16 @@ namespace
         locationManager::updateCurrentLocation(locationManager::locationMap[3]);
         // Pick up mushroom 
         EXPECT_TRUE(CP->interpretCommand("pick apple"));
-        // Yes/No needs cin, so fake it
-        streambuf *cinbuf = std::cin.rdbuf();
-        std::stringstream ss;
-        ss << "yes\n";
-        cin.rdbuf(ss.rdbuf());
+
+        // Yes/No needs an input, so fake it
+        PrintDisplay::GT_setString("yes\n");
+    
         // Eat the apple
         testing::internal::CaptureStdout();
         EXPECT_TRUE(CP->interpretCommand("eat apple"));
         string output = testing::internal::GetCapturedStdout();
-        // Reset cin
-        cin.rdbuf(cinbuf);
-        EXPECT_EQ(output,"\nYou already have max health, are you sure you want to eat the apple?\n\nYes or no?\n> \nYou eat the apple!\n\nYou healed by 1 HP!\n");
+
+        EXPECT_EQ(output,"\nYou already have max health, are you sure you want to eat the apple?\n\nYes or no?\n> yes\n\r\nYou eat the apple!\n\nYou healed by 1 HP!\n");
         EXPECT_EQ(playeract.checkPlayerHealth(), playeract.checkMaxPlayerHealth());
 
     }
@@ -442,14 +440,9 @@ namespace
         playeract.healthMGR.removeHP(999);
 
         // Yes to play again
-        streambuf* cinbuf = std::cin.rdbuf();
-        std::stringstream ss;
-        ss << "yes\n";
-        cin.rdbuf(ss.rdbuf());
-
-        // Play again
+        PrintDisplay::GT_setString("yes\n");
         playeract.playAgain();
-        cin.rdbuf(cinbuf);
+
 
         // Nothing should be in the inventory
         EXPECT_EQ(userInventory->currentInventory.size(), 0);


### PR DESCRIPTION
## ~Note: On hold until all tests [MBUILD-141](https://csc-fdu.atlassian.net/browse/MBUILD-141) and [MBUILD-142](https://csc-fdu.atlassian.net/browse/MBUILD-142) are fixed.~

# Command Logger and Backtracking
A major UI and debugging upgrade.

### This PR handles:
* Receiving input from the terminal
* Arrow key commands
    * Up or down shows the last valid command inputted
    * Left or right moves the cursor

This PR also paves the way for the custom TerminalDisplay library used in the TicTacToe project.

### New requirements:
* NCurses Library (for macOS/Unix)


### How to test
* Typing in a command. 
* Pressing enter to submit a command
* Pressing up or down arrows
    * should beep (or play a sound) if there are no previous commands, or at the end of history.
* Left and right arrows move the cursors.
* YesNo Prompt cannot do up or down
* Google Tests still run correctly (with a few modifications)

[MBUILD-141]: https://csc-fdu.atlassian.net/browse/MBUILD-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBUILD-142]: https://csc-fdu.atlassian.net/browse/MBUILD-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ